### PR TITLE
Added support for saving multiple logs at once.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ ui_*.h
 # QtCtreator CMake
 CMakeLists.txt.user*
 
+# Auto-generated makefile
+Makefile

--- a/main.cpp
+++ b/main.cpp
@@ -28,6 +28,7 @@
 #include <QLibraryInfo>
 #include <QLocale>
 #include <QTranslator>
+#include <QMessageBox>
 
 #include "mainwindow.h"
 #include <unistd.h>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -90,7 +90,7 @@ void MainWindow::setup()
     selall->setShortcutVisibleInContextMenu(true);
     connect(selall, &QAction::triggered, this, &MainWindow::listSelectAll);
     QAction *seldef = new QAction(QIcon::fromTheme(QStringLiteral("edit-clear-all")),
-        tr("Reset Selection"), this);
+        tr("Revert Selection"), this);
     seldef->setShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_A);
     seldef->setShortcutVisibleInContextMenu(true);
     connect(seldef, &QAction::triggered, this, &MainWindow::listSelectDefault);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -48,10 +48,9 @@ MainWindow::MainWindow(const QCommandLineParser &arg_parser, QWidget *parent)
     lockGUI(true);
     setWindowFlags(Qt::Window); // for the close, min and max buttons
     ui->textSysInfo->setWordWrapMode(QTextOption::NoWrap);
-    ui->textSysInfo->setContextMenuPolicy(Qt::CustomContextMenu);
+    ui->textSysInfo->setContextMenuPolicy(Qt::ActionsContextMenu);
     ui->textSysInfo->setPlainText(tr("Loading..."));
     resize(QGuiApplication::primaryScreen()->availableGeometry().size() * 0.6);
-    connect(ui->textSysInfo, &QPlainTextEdit::customContextMenuRequested, this, &MainWindow::createmenu);
     ui->listInfo->setContextMenuPolicy(Qt::ActionsContextMenu);
     // This fires the lengthy setup routine after the window is displayed.
     QTimer::singleShot(0, this, &MainWindow::setup);
@@ -66,19 +65,26 @@ void MainWindow::setup()
     buildInfoList();
     ui->listInfo->setCurrentRow(0);
 
-    QAction *copyreport = new QAction(this);
-    copyreport->setShortcut(Qt::CTRL | Qt::Key_C);
-    connect(copyreport, &QAction::triggered, this, &MainWindow::forumcopy);
-    QAction *plaincopyaction = new QAction(this);
-    connect(plaincopyaction, &QAction::triggered, this, &MainWindow::plaincopy);
+    // Log text box shortcuts and context menu
+    QAction *forumcopyaction = new QAction(QIcon::fromTheme(QStringLiteral("edit-copy-symbolic")),
+        tr("Copy for forum"), this);
+    forumcopyaction->setShortcutVisibleInContextMenu(true);
+    forumcopyaction->setShortcut(Qt::CTRL | Qt::Key_C);
+    connect(forumcopyaction, &QAction::triggered, this, &MainWindow::forumcopy);
+    QAction *plaincopyaction = new QAction(QIcon::fromTheme(QStringLiteral("edit-copy-symbolic")),
+        tr("Plain text copy"), this);
+    plaincopyaction->setShortcutVisibleInContextMenu(true);
     plaincopyaction->setShortcut(Qt::ALT | Qt::Key_C);
-    QAction *savefileaction = new QAction(this);
-    connect(savefileaction, &QAction::triggered, this, &MainWindow::on_pushSave_clicked);
-    savefileaction->setShortcut(Qt::CTRL | Qt::Key_S);
+    connect(plaincopyaction, &QAction::triggered, this, &MainWindow::plaincopy);
+    QAction *saveasfile = new QAction(QIcon::fromTheme(QStringLiteral("document-save")),
+        tr("Save"), this);
+    saveasfile->setShortcutVisibleInContextMenu(true);
+    saveasfile->setShortcut(Qt::CTRL | Qt::Key_S);
+    connect(saveasfile, &QAction::triggered, this, &MainWindow::on_pushSave_clicked);
 
-    this->addAction(copyreport);
-    this->addAction(plaincopyaction);
-    this->addAction(savefileaction);
+    ui->textSysInfo->addAction(forumcopyaction);
+    ui->textSysInfo->addAction(plaincopyaction);
+    ui->textSysInfo->addAction(saveasfile);
 
     // Info list shortcuts and context menu.
     QAction *selall = new QAction(QIcon::fromTheme(QStringLiteral("edit-select-all")),
@@ -92,15 +98,15 @@ void MainWindow::setup()
     seldef->setShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_A);
     seldef->setShortcutVisibleInContextMenu(true);
     connect(seldef, &QAction::triggered, this, &MainWindow::listSelectDefault);
-    QAction *save = new QAction(QIcon::fromTheme(QStringLiteral("document-save")),
+    QAction *multisave = new QAction(QIcon::fromTheme(QStringLiteral("document-save")),
         ui->pushSaveMulti->text(), this);
-    save->setShortcut(Qt::ALT | Qt::Key_S);
-    save->setShortcutVisibleInContextMenu(true);
-    connect(save, &QAction::triggered, this, &MainWindow::on_pushSaveMulti_clicked);
+    multisave->setShortcut(Qt::ALT | Qt::Key_S);
+    multisave->setShortcutVisibleInContextMenu(true);
+    connect(multisave, &QAction::triggered, this, &MainWindow::on_pushSaveMulti_clicked);
 
     ui->listInfo->addAction(selall);
     ui->listInfo->addAction(seldef);
-    ui->listInfo->addAction(save);
+    ui->listInfo->addAction(multisave);
 
     ui->ButtonCopy->setDefault(true);
     lockGUI(false);
@@ -307,31 +313,6 @@ void MainWindow::plaincopy()
         text = ui->textSysInfo->toPlainText();
     }
     clipboard->setText(text);
-}
-
-void MainWindow::createmenu(QPoint pos)
-{
-    QMenu menu(this);
-    forumcopyaction = new QAction(QIcon::fromTheme(QStringLiteral("edit-copy-symbolic")), tr("Copy for forum"), this);
-    forumcopyaction->setShortcutVisibleInContextMenu(true);
-    forumcopyaction->setShortcut(Qt::CTRL | Qt::Key_C);
-    connect(forumcopyaction, &QAction::triggered, this, &MainWindow::forumcopy);
-    plaincopyaction = new QAction(QIcon::fromTheme(QStringLiteral("edit-copy-symbolic")), tr("Plain text copy"), this);
-    plaincopyaction->setShortcutVisibleInContextMenu(true);
-    plaincopyaction->setShortcut(Qt::ALT | Qt::Key_C);
-    connect(plaincopyaction, &QAction::triggered, this, &MainWindow::plaincopy);
-    saveasfile = new QAction(QIcon::fromTheme(QStringLiteral("document-save")), tr("Save"), this);
-    saveasfile->setShortcutVisibleInContextMenu(true);
-    saveasfile->setShortcut(Qt::CTRL | Qt::Key_S);
-    connect(saveasfile, &QAction::triggered, this, &MainWindow::on_pushSave_clicked);
-    menu.addAction(forumcopyaction);
-    menu.addAction(plaincopyaction);
-    menu.addAction(saveasfile);
-
-    menu.exec(ui->textSysInfo->mapToGlobal(pos));
-    forumcopyaction->deleteLater();
-    plaincopyaction->deleteLater();
-    saveasfile->deleteLater();
 }
 
 QString MainWindow::readlog(const QString &logfile)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -405,9 +405,16 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event)
             // Auto-resize splitter to fit list column.
             QList<int> sizes = ui->splitter->sizes();
             if(sizes.count() > 1) {
+                int shint = ui->listInfo->sizeHintForColumn(0);
+                if (sizes.at(0) <= 0) {
+                    // If the list is collapsed, pre-size it to ensure correct calculations.
+                    sizes[0] = shint;
+                    sizes[1] -= shint;
+                    ui->splitter->setSizes(sizes);
+                    sizes = ui->splitter->sizes();
+                }
                 const int total = sizes.at(0) + sizes.at(1);
-                const int shint = ui->listInfo->sizeHintForColumn(0)
-                                  + (sizes.at(0) - ui->listInfo->viewport()->contentsRect().width());
+                shint += sizes.at(0) - ui->listInfo->viewport()->contentsRect().width();
                 sizes[0] = shint;
                 sizes[1] = total - shint;
                 ui->splitter->setSizes(sizes);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -28,12 +28,11 @@
 #include <QDir>
 #include <QFileDialog>
 #include <QFileInfo>
-#include <QPoint>
+#include <QMessageBox>
 #include <QScreen>
-#include <QTextEdit>
 #include <QTimer>
+#include <QClipboard>
 
-#include "QClipboard"
 #include "about.h"
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
@@ -62,8 +61,6 @@ MainWindow::~MainWindow() { delete ui; }
 // setup versious items first time program runs
 void MainWindow::setup()
 {
-    version = getVersion("quick-system-info-gui");
-
     // Log text box shortcuts and context menu
     QAction *forumcopyaction = new QAction(QIcon::fromTheme(QStringLiteral("edit-copy-symbolic")),
         tr("Copy for forum"), this);
@@ -110,6 +107,7 @@ void MainWindow::setup()
     buildInfoList();
     ui->listInfo->setCurrentRow(0);
 
+    connect(ui->ButtonCopy, &QPushButton::clicked, this, &MainWindow::forumcopy);
     ui->ButtonCopy->setDefault(true);
     lockGUI(false);
 }
@@ -137,9 +135,6 @@ Result MainWindow::runCmd(const QString &cmd)
     loop.exec();
     return {proc.exitCode(), proc.readAll().trimmed()};
 }
-
-// Get version of the program
-QString MainWindow::getVersion(const QString &name) { return runCmd("dpkg-query -f '${Version}' -W " + name).output; }
 
 // About button clicked
 void MainWindow::on_buttonAbout_clicked()
@@ -221,8 +216,6 @@ void MainWindow::on_pushMultiSave_clicked()
         lockGUI(false);
     }
 }
-
-void MainWindow::on_ButtonCopy_clicked() { forumcopy(); }
 
 QString MainWindow::systeminfo()
 {
@@ -403,6 +396,7 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event)
 {
     if (event->type() == QEvent::MouseButtonDblClick) {
         if (watched == ui->splitter->handle(1)) {
+            // Auto-resize splitter to fit list column.
             QList<int> sizes = ui->splitter->sizes();
             if(sizes.count() > 1) {
                 const int total = sizes.at(0) + sizes.at(1);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -61,6 +61,12 @@ MainWindow::~MainWindow() { delete ui; }
 // setup versious items first time program runs
 void MainWindow::setup()
 {
+    // Allow user-friendly match strings.
+    for(QString &match : defaultMatches) {
+        match.replace('/', '+');
+        if (!match.contains('.')) match.append(QStringLiteral(".txt"));
+    }
+
     // Log text box shortcuts and context menu
     QAction *forumcopyaction = new QAction(QIcon::fromTheme(QStringLiteral("edit-copy-symbolic")),
         tr("Copy for forum"), this);
@@ -379,16 +385,16 @@ void MainWindow::listSelectAll()
 void MainWindow::listSelectDefault()
 {
     const int lcount = ui->listInfo->count();
-    if (lcount > 0) ui->listInfo->item(0)->setCheckState(Qt::Checked);
-    for(int row = 1; row < lcount; ++row) {
-        ui->listInfo->item(row)->setCheckState(Qt::Unchecked);
+    if (lcount > 0) {
+        // Quick System Info should always be selected.
+        ui->listInfo->item(0)->setCheckState(Qt::Checked);
     }
-    // Check any items that match what is specified on the command line.
-    for(const QString &match : qAsConst(defaultMatches)) {
-        QList<QListWidgetItem *> matched = ui->listInfo->findItems(match, Qt::MatchWildcard);
-        for(QListWidgetItem *item : matched) {
-            item->setCheckState(Qt::Checked);
-        }
+    for(int row = 1; row < lcount; ++row) {
+        QListWidgetItem *item = ui->listInfo->item(row);
+        assert(item != nullptr);
+        const bool sel = defaultMatches.contains(item->data(Qt::UserRole).toString(),
+            Qt::CaseInsensitive);
+        item->setCheckState(sel ? Qt::Checked : Qt::Unchecked);
     }
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -61,16 +61,19 @@ public:
     void setup();
 
 private slots:
+    void on_pushSaveMulti_clicked();
     void on_pushSave_clicked();
     void on_ButtonCopy_clicked();
     void on_buttonAbout_clicked();
     void on_ButtonHelp_clicked();
+    void on_listInfo_itemSelectionChanged();
 
-    void on_comboBoxCommand_currentIndexChanged(int index);
+    void on_listInfo_itemChanged();
 
 private:
     Ui::MainWindow *ui;
     QSettings user_settings;
+    void lockGUI(bool lock);
     void forumcopy();
     void plaincopy();
     QMenu *menu {};
@@ -78,10 +81,12 @@ private:
     QAction *plaincopyaction {};
     QAction *saveasfile {};
     void createmenu(QPoint pos);
-    void systeminfo();
-    void apthistory();
-    void displaylog(const QString &logfile);
-    void buildcomboBoxCommand();
+    QString systeminfo();
+    QString apthistory();
+    QString readlog(const QString &logfile);
+    void buildInfoList();
+    void listSelectAll();
+    void listSelectDefault();
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -26,11 +26,10 @@
 #define MAINWINDOW_H
 
 #include <QCommandLineParser>
-#include <QMenu>
-#include <QMessageBox>
-#include <QPoint>
+#include <QDialog>
+#include <QAction>
+#include <QEvent>
 #include <QProcess>
-#include <QSettings>
 
 namespace Ui
 {
@@ -54,25 +53,19 @@ public:
     ~MainWindow();
 
     Result runCmd(const QString &cmd);
-    QString getVersion(const QString &name);
 
-    QString version;
-    QString output;
     void setup();
 
 private slots:
     void on_pushMultiSave_clicked();
     void on_pushSave_clicked();
-    void on_ButtonCopy_clicked();
     void on_buttonAbout_clicked();
     void on_ButtonHelp_clicked();
     void on_listInfo_itemSelectionChanged();
-
     void on_listInfo_itemChanged();
 
 private:
     Ui::MainWindow *ui;
-    QSettings user_settings;
     QStringList defaultMatches;
     QAction *actionMultiSave = nullptr;
     void lockGUI(bool lock);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -84,6 +84,7 @@ private:
     void buildInfoList();
     void listSelectAll();
     void listSelectDefault();
+    bool eventFilter(QObject *watched, QEvent *event);
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -76,11 +76,6 @@ private:
     void lockGUI(bool lock);
     void forumcopy();
     void plaincopy();
-    QMenu *menu {};
-    QAction *forumcopyaction {};
-    QAction *plaincopyaction {};
-    QAction *saveasfile {};
-    void createmenu(QPoint pos);
     QString systeminfo();
     QString apthistory();
     QString readlog(const QString &logfile);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -61,7 +61,7 @@ public:
     void setup();
 
 private slots:
-    void on_pushSaveMulti_clicked();
+    void on_pushMultiSave_clicked();
     void on_pushSave_clicked();
     void on_ButtonCopy_clicked();
     void on_buttonAbout_clicked();
@@ -73,6 +73,7 @@ private slots:
 private:
     Ui::MainWindow *ui;
     QSettings user_settings;
+    QAction *actionMultiSave = nullptr;
     void lockGUI(bool lock);
     void forumcopy();
     void plaincopy();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -73,6 +73,7 @@ private slots:
 private:
     Ui::MainWindow *ui;
     QSettings user_settings;
+    QStringList defaultMatches;
     QAction *actionMultiSave = nullptr;
     void lockGUI(bool lock);
     void forumcopy();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -29,7 +29,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>MX Welcome</string>
+   <string>Quick System Info</string>
   </property>
   <property name="windowIcon">
    <iconset theme="mx-qsi">
@@ -42,22 +42,20 @@
    <bool>false</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
-   <item row="0" column="0">
-    <layout class="QGridLayout" name="gridLayout_2"/>
-   </item>
    <item row="1" column="0">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
     <widget class="QWidget" name="widget" native="true">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
      </property>
      <property name="baseSize">
       <size>
@@ -68,107 +66,115 @@
      <property name="styleSheet">
       <string notr="true">QTabBar::tab { height: 30px; width: 326px; } </string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="1" column="0">
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0" colspan="2">
-         <widget class="QPlainTextEdit" name="textSysInfo">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="baseSize">
-           <size>
-            <width>800</width>
-            <height>500</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <family>Monospace</family>
-           </font>
-          </property>
-          <property name="contextMenuPolicy">
-           <enum>Qt::DefaultContextMenu</enum>
-          </property>
-          <property name="readOnly">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QPushButton" name="pushSave">
-          <property name="toolTip">
-           <string>Save the system information to a text file.</string>
-          </property>
-          <property name="text">
-           <string>&amp;Save</string>
-          </property>
-          <property name="icon">
-           <iconset theme="document-save">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QPushButton" name="ButtonCopy">
-          <property name="toolTip">
-           <string>Copy the system information to the clipboard, encased in [CODE][/CODE] tags ready to use in a forum post.</string>
-          </property>
-          <property name="text">
-           <string>&amp;Copy for forum</string>
-          </property>
-          <property name="icon">
-           <iconset theme="edit-copy">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
-          <property name="shortcut">
-           <string>C</string>
-          </property>
-          <property name="default">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="1" column="2">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
-      <item row="0" column="0">
-       <widget class="QComboBox" name="comboBoxCommand"/>
+      <item row="1" column="3" colspan="2">
+       <widget class="QPushButton" name="pushSave">
+        <property name="toolTip">
+         <string>Save the system information to a text file.</string>
+        </property>
+        <property name="text">
+         <string>&amp;Save</string>
+        </property>
+        <property name="icon">
+         <iconset theme="document-save">
+          <normaloff>.</normaloff>.</iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="6">
+       <widget class="QPushButton" name="ButtonCopy">
+        <property name="toolTip">
+         <string>Copy the system information to the clipboard, encased in [CODE][/CODE] tags ready to use in a forum post.</string>
+        </property>
+        <property name="text">
+         <string>&amp;Copy for forum</string>
+        </property>
+        <property name="icon">
+         <iconset theme="edit-copy">
+          <normaloff>.</normaloff>.</iconset>
+        </property>
+        <property name="shortcut">
+         <string>C</string>
+        </property>
+        <property name="default">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="7">
+       <widget class="QSplitter" name="splitter">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <widget class="QListWidget" name="listInfo">
+         <property name="contextMenuPolicy">
+          <enum>Qt::ActionsContextMenu</enum>
+         </property>
+        </widget>
+        <widget class="QPlainTextEdit" name="textSysInfo">
+         <property name="baseSize">
+          <size>
+           <width>800</width>
+           <height>500</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <family>Monospace</family>
+          </font>
+         </property>
+         <property name="lineWrapMode">
+          <enum>QPlainTextEdit::NoWrap</enum>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QPushButton" name="pushSaveMulti">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset theme="document-save">
+          <normaloff>.</normaloff>.</iconset>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
     <layout class="QGridLayout" name="buttonBar">
-     <property name="leftMargin">
-      <number>9</number>
-     </property>
-     <property name="rightMargin">
-      <number>9</number>
-     </property>
-     <property name="bottomMargin">
-      <number>9</number>
+     <property name="topMargin">
+      <number>0</number>
      </property>
      <item row="0" column="4">
       <widget class="QLabel" name="labelMX">
@@ -318,12 +324,12 @@
    <slot>close()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>663</x>
-     <y>458</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>388</x>
-     <y>272</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -158,10 +158,7 @@
        </widget>
       </item>
       <item row="1" column="0" colspan="2">
-       <widget class="QPushButton" name="pushSaveMulti">
-        <property name="text">
-         <string/>
-        </property>
+       <widget class="QPushButton" name="pushMultiSave">
         <property name="icon">
          <iconset theme="document-save">
           <normaloff>.</normaloff>.</iconset>

--- a/quick-system-info-gui.pro
+++ b/quick-system-info-gui.pro
@@ -35,7 +35,8 @@ SOURCES += main.cpp\
 
 HEADERS  += \
     about.h \
-    mainwindow.h
+    mainwindow.h \
+    version.h
 
 FORMS    += \
     mainwindow.ui

--- a/quick-system-info-gui.pro
+++ b/quick-system-info-gui.pro
@@ -105,4 +105,4 @@ TRANSLATIONS += translations/quick-system-info-gui_af.ts \
 
 RESOURCES +=
 
-
+CONFIG += release warn_on c++17


### PR DESCRIPTION
We often ask users to provide the Quick System Info as well as other log files. The current QSI app can save one log at a time and doing so can be painful especially for a newer user.

### Info source list
This changeset replaces the combo box with a list on the left, which the user can select multiple sources and save the selected files to a directory all at once. A splitter in between the list and text box allows the user to resize the boxes, or even collapse the list if necessary. Double-clicking this will auto-resize to the width of the list contents.

If an item is in _italics_ it requires root to read.

### New shortcuts
- Ctrl+A (with list box in focus) - select all items in the list.
- Ctrl+A (while in text box) - select all text (pre-existing shortcut).
- Ctrl+Shift+A - revert selection of the list to when the program was started.
- Ctrl+Shift+S - Save selected items (if any). Does nothing if nothing is selected.

### Pre-selected items (default selection)
QSI is always pre-selected, but additional items can be pre-selected using the command line. This could be useful for automatically running QSI when a process like minstall crashes.
For example, to pre-select QSI, minstall.log and trim.log: **quick-system-info-gui minstall.log trim.log**
The _Revert Selection_ menu item will revert it to the pre-selected items, in the above example QSI, minstall.log and trim.log.