### PR TITLE
Absorb the quick-system-info-mx logic.

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -280,17 +280,19 @@ QString MainWindow::systeminfo()
         snapshot.prepend("Snapshot created on: ");
         snapshot.append('\n');
     }
-    Result out = runCmd(QStringLiteral("inxi -Fxxxrza -c0"));
+    Result out = runCmd("inxi -Fxxxra --filter-all -c0");
 
+    // Deal with bugs in inxi.
+    out.output.replace("http: /", "http:/");
+    out.output.replace("https: /", "https:/");
     // Filtering
     const QString unamev = runCmd("uname -v | grep -oP '.*[[:space:]]\\K([0-9]+[.])+[^[:space:]]*'").output;
     static const QRegularExpression kernel_add("(.+Kernel:(" "\\x1b\\[[0-9;]+[mK]" "|[[:space:]])+[[:alnum:].-]+)(.*)");
     out.output.replace(kernel_add, "\\1 [" + unamev + "]\\3");
-    static const QRegularExpression uuid_filter("[[:xdigit:]]{8}-([[:xdigit:]]{4}-){3}[[:xdigit:]]{12}");
-    out.output.replace(uuid_filter, "<filter>");
-    // Final filtering
-    out.output.replace("http: /", "http:/");
-    out.output.replace("https: /", "https:/");
+//    static const QRegularExpression host_filter("(.+Host:(" "\\x1b\\[[0-9;]+[mK]" "|[[:space:]])+)([[:alnum:].-]+)(.*)");
+//    out.output.replace(host_filter, "\\1<filter>\\4");
+//    static const QRegularExpression uuid_filter("[[:xdigit:]]{8}-([[:xdigit:]]{4}-){3}[[:xdigit:]]{12}");
+//    out.output.replace(uuid_filter, "<filter>");
 
     // Extra information not provided by inxi
     out.output.append("\n\nBoot Mode: ");

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -402,7 +402,7 @@ QString MainWindow::readfile(const QString &logfile, bool escalate)
         }
         file.close();
     } else if (escalate) {
-        text = runCmd("pkexec /usr/lib/quick-system-info-gui/qsig-lib readadminfile /var/log/" + logfile).output;
+        text = runCmd("pkexec /usr/lib/quick-system-info-gui/qsig-lib readadminfile " + logfile).output;
     }
 
     return text.trimmed();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -286,8 +286,6 @@ QString MainWindow::systeminfo()
     const QString unamev = runCmd("uname -v | grep -oP '.*[[:space:]]\\K([0-9]+[.])+[^[:space:]]*'").output;
     static const QRegularExpression kernel_add("(.+Kernel:(" "\\x1b\\[[0-9;]+[mK]" "|[[:space:]])+[[:alnum:].-]+)(.*)");
     out.output.replace(kernel_add, "\\1 [" + unamev + "]\\3");
-    static const QRegularExpression host_filter("(.+Host:(" "\\x1b\\[[0-9;]+[mK]" "|[[:space:]])+)([[:alnum:].-]+)(.*)");
-    out.output.replace(host_filter, "\\1<filter>\\4");
     static const QRegularExpression uuid_filter("[[:xdigit:]]{8}-([[:xdigit:]]{4}-){3}[[:xdigit:]]{12}");
     out.output.replace(uuid_filter, "<filter>");
     // Final filtering

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -51,6 +51,7 @@ MainWindow::MainWindow(const QCommandLineParser &arg_parser, QWidget *parent)
     ui->setupUi(this);
     lockGUI(true);
     setWindowFlags(Qt::Window); // for the close, min and max buttons
+    connect(ui->buttonCancel, &QPushButton::clicked, this, &MainWindow::close);
     ui->textSysInfo->setWordWrapMode(QTextOption::NoWrap);
     ui->textSysInfo->setContextMenuPolicy(Qt::ActionsContextMenu);
     ui->textSysInfo->setPlainText(tr("Loading..."));

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -52,7 +52,7 @@ public:
     explicit MainWindow(const QCommandLineParser &arg_parser, QWidget *parent = nullptr);
     ~MainWindow();
 
-    Result runCmd(const QString &cmd);
+    Result runCmd(const QString &cmd, const QString *input = nullptr);
 
     void setup();
 
@@ -74,7 +74,7 @@ private:
     void showSavedMessage(const QString &filename, const QString &errmsg);
     QString systeminfo();
     QString apthistory();
-    QString readlog(const QString &logfile);
+    QString readfile(const QString &logfile, bool escalate = true);
     void buildInfoList();
     void listSelectAll();
     void listSelectDefault();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -29,7 +29,6 @@
 #include <QDialog>
 #include <QAction>
 #include <QEvent>
-#include <QProcess>
 
 namespace Ui
 {
@@ -44,9 +43,6 @@ struct Result {
 class MainWindow : public QDialog
 {
     Q_OBJECT
-
-protected:
-    QProcess *proc {};
 
 public:
     explicit MainWindow(const QCommandLineParser &arg_parser, QWidget *parent = nullptr);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -48,7 +48,12 @@ public:
     explicit MainWindow(const QCommandLineParser &arg_parser, QWidget *parent = nullptr);
     ~MainWindow();
 
-    Result runCmd(const QString &cmd, const QString *input = nullptr);
+    Result run(const char *program, const QStringList &args = QStringList(),
+        const QString *input = nullptr);
+    inline Result shell(const QString &cmd, const QString *input = nullptr)
+    {
+        return run("/bin/bash", {"-c", cmd}, input);
+    }
 
     void setup();
 
@@ -70,7 +75,7 @@ private:
     void showSavedMessage(const QString &filename, const QString &errmsg);
     QString systeminfo();
     QString apthistory();
-    QString readfile(const QString &logfile, bool escalate = true);
+    QString readfile(const QString &path, bool escalate = true);
     void buildInfoList();
     void listSelectAll();
     void listSelectDefault();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -297,12 +297,4 @@
  <resources>
   <include location="qsi_resource.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>buttonCancel</sender>
-   <signal>clicked()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>close()</slot>
-  </connection>
- </connections>
 </ui>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -145,6 +145,9 @@
          <property name="readOnly">
           <bool>true</bool>
          </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
         </widget>
        </widget>
       </item>


### PR DESCRIPTION
This means the QSI GUI does not need quick-system-info-mx, and adding custom filters is easy with QRegularExpression.
Since quick-system-info-mx is now redundant and we don't even provide a shortcut to it anymore, it can be removed from mx-goodies. Also consider renaming _quick-system-info-gui_ to _mx-quick-system-info_ to make it consistent with the rest of the MX tools.

I have changed the command from `inxi -Fxxxrza` to `inxi -Fxxxra --filter-all -c0` to activate all the filters. It doesn't look like it filters out too much, so should be safe, but it's always possible to change that back and uncomment the regex filters.