### PR TITLE
Small optimizations

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -331,7 +331,7 @@ void MainWindow::buildInfoList() noexcept
     // Special apt history info
     item = new QListWidgetItem("apt " + tr("history"));
     item->setData(Qt::UserRole, "apthistory.txt");
-    if (QFile("/var/log/dpkg.log").exists()){
+    if (QFile::exists("/var/log/dpkg.log")){
         ui->listInfo->insertItem(1, item);
     }
     listSelectDefault();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -47,7 +47,7 @@
 #include "ui_mainwindow.h"
 #include "version.h"
 
-MainWindow::MainWindow(const QCommandLineParser &arg_parser, QWidget *parent)
+MainWindow::MainWindow(const QCommandLineParser &arg_parser, QWidget *parent) noexcept
     : QDialog(parent)
     , ui(new Ui::MainWindow)
 {

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -41,7 +41,7 @@ class MainWindow : public QDialog
     Q_OBJECT
 
 public:
-    explicit MainWindow(const QCommandLineParser &arg_parser, QWidget *parent = nullptr);
+    explicit MainWindow(const QCommandLineParser &arg_parser, QWidget *parent = nullptr) noexcept;
     ~MainWindow();
 
     int run(const char *program, const QStringList &args = QStringList(),


### PR DESCRIPTION
 - Mark constructors as noexcept to save on exception handling runtime code.
 - Static QFile::exists() is faster than creating an entire QFile object just to check if a file exists.